### PR TITLE
Add two c6.99 mock configs for bootstrapping the i386 environment.

### DIFF
--- a/mock/c6.99.00.el7-i686.cfg
+++ b/mock/c6.99.00.el7-i686.cfg
@@ -1,0 +1,28 @@
+config_opts['root'] = 'c6.99.00-i686'
+config_opts['basedir'] = 'MOCKROOT'
+config_opts['target_arch'] = 'i686'
+config_opts['legal_host_arches'] = ('i386', 'i486', 'i586', 'i686', 'x86_64',)
+config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils system-release findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux which xz'
+config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
+
+config_opts['yum.conf'] = """
+[main]
+cachedir=/var/cache/yum
+debuglevel=1
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+
+exclude=*.x86_64
+
+# repos
+[base]
+name=BaseOS
+enabled=1
+baseurl=http://repohost/repo/mirror/f19-i686/
+"""

--- a/mock/c6.99.01.el7-i686.cfg
+++ b/mock/c6.99.01.el7-i686.cfg
@@ -1,0 +1,28 @@
+config_opts['root'] = 'c6.99.01-i686'
+config_opts['basedir'] = 'MOCKROOT'
+config_opts['target_arch'] = 'i686'
+config_opts['legal_host_arches'] = ('i386', 'i486', 'i586', 'i686', 'x86_64',)
+config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils system-release findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux which xz'
+config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
+
+config_opts['yum.conf'] = """
+[main]
+cachedir=/var/cache/yum
+debuglevel=1
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+
+exclude=*.x86_64
+
+# repos
+[base]
+name=BaseOS
+enabled=1
+baseurl=http://repohost/tmp/repo/c6.99.00-i686/
+"""


### PR DESCRIPTION
The initial build .00 is built purely against f19 to bootstrap the environment.
The second build .01 is built against the results of .00 which will have picked up a bunch of f19 dependencies which will fail now. We need to get rid of these.

The third build to be pushed in a later commit should be looking cleaner then and have most of these packages build fine and mostly the right dependencies.
